### PR TITLE
Quick fix for issue #209

### DIFF
--- a/POE-ItemInfo.ahk
+++ b/POE-ItemInfo.ahk
@@ -458,7 +458,7 @@ class ItemData_ {
 }
 ItemData := new ItemData_()
 
-class Item {
+class Item_ {
 	; Initialize all the Item object attributes to default values
 	Init()
 	{
@@ -504,7 +504,7 @@ class Item {
 		This.IsEssence := False
 	}
 }
-Item := new Item()
+Global Item := new Item_
 Item.Init()
 
 class AffixTotals_ {
@@ -6357,7 +6357,7 @@ ItemIsMirrored(ItemDataText)
 ;
 ParseItemData(ItemDataText, ByRef RarityLevel="")
 {
-	Global Item, ItemData, AffixTotals, uniqueMapList, mapList, mapMatchList, shapedMapMatchList, divinationCardList, gemQualityList
+	Global ItemData, AffixTotals, uniqueMapList, mapList, mapMatchList, shapedMapMatchList, divinationCardList, gemQualityList
 
 	ItemDataPartsIndexLast =
 	ItemDataPartsIndexAffixes =

--- a/POE-ItemInfo.ahk
+++ b/POE-ItemInfo.ahk
@@ -435,28 +435,23 @@ class Fonts {
 }
 
 class ItemData_ {
-
-	Links := ""
-	Sockets := ""
-	Stats := ""
-	NamePlate := ""
-	Affixes := ""
-	FullText := ""
-	IndexAffixes := -1
-	IndexLast := -1
-	PartsLast := ""
-	Rarity := ""
-	Parts := []
-
-	ClearParts()
+	Init() 
 	{
-		Loop, % this.Parts.MaxIndex()
-		{
-			this.Parts.Remove(this.Parts.MaxIndex())
-		}
+		This.Links := ""
+		This.Sockets := ""
+		This.Stats := ""
+		This.NamePlate := ""
+		This.Affixes := ""
+		This.FullText := ""
+		This.IndexAffixes := -1
+		This.IndexLast := -1
+		This.PartsLast := ""
+		This.Rarity := ""
+		This.Parts := []
 	}
 }
-ItemData := new ItemData_()
+Global ItemData := new ItemData_
+ItemData.Init()
 
 class Item_ {
 	; Initialize all the Item object attributes to default values
@@ -6357,7 +6352,7 @@ ItemIsMirrored(ItemDataText)
 ;
 ParseItemData(ItemDataText, ByRef RarityLevel="")
 {
-	Global ItemData, AffixTotals, uniqueMapList, mapList, mapMatchList, shapedMapMatchList, divinationCardList, gemQualityList
+	Global AffixTotals, uniqueMapList, mapList, mapMatchList, shapedMapMatchList, divinationCardList, gemQualityList
 
 	ItemDataPartsIndexLast =
 	ItemDataPartsIndexAffixes =
@@ -6381,6 +6376,7 @@ ParseItemData(ItemDataText, ByRef RarityLevel="")
 	TempResult =
 
 	Item.Init()
+	ItemData.Init()
 
 	ResetAffixDetailVars()
 
@@ -6406,7 +6402,6 @@ ParseItemData(ItemDataText, ByRef RarityLevel="")
 	ItemDataIndexLast := ItemDataParts0
 	ItemDataPartsLast := ItemDataParts%ItemDataIndexLast%
 
-	ItemData.ClearParts()
 	Loop, %ItemDataParts0%
 	{
 		ItemData.Parts[A_Index] := ItemDataParts%A_Index%

--- a/resources/ahk/TradeMacro.ahk
+++ b/resources/ahk/TradeMacro.ahk
@@ -604,9 +604,7 @@ TradeFunc_Main(openSearchInBrowser = false, isAdvancedPriceCheck = false, isAdva
 		ShowToolTip("")
 		ShowToolTip(ParsedData)
 	}    
-	
-	; reset ItemData after search
-	ItemData := {}
+
 	TradeGlobals.Set("AdvancedPriceCheckItem", {})
 }
 

--- a/resources/ahk/TradeMacro.ahk
+++ b/resources/ahk/TradeMacro.ahk
@@ -5,7 +5,6 @@ PriceCheck:
 	IfWinActive, Path of Exile ahk_class POEWindowClass 
 	{
 		Global TradeOpts, Item
-		Item := {}
 		SuspendPOEItemScript = 1 ; This allows us to handle the clipboard change event
 		Send ^{sc02E}
 		Sleep 250
@@ -18,7 +17,6 @@ AdvancedPriceCheck:
 	IfWinActive, Path of Exile ahk_class POEWindowClass 
 	{
 		Global TradeOpts, Item
-		Item := {}
 		SuspendPOEItemScript = 1 ; This allows us to handle the clipboard change event
 		Send ^{sc02E}
 		Sleep 250
@@ -35,7 +33,6 @@ ShowItemAge:
 			ShowTooltip("No Account Name specified in settings menu.")
 			return
 		}
-		Item := {}
 		SuspendPOEItemScript = 1 ; This allows us to handle the clipboard change event
 		Send ^{sc02E}
 		Sleep 250
@@ -48,7 +45,6 @@ OpenWiki:
 	IfWinActive, Path of Exile ahk_class POEWindowClass 
 	{
 		Global TradeOpts, Item
-		Item := {}
 		SuspendPOEItemScript = 1 ; This allows us to handle the clipboard change event
 		Send ^{sc02E}
 		Sleep 250
@@ -88,7 +84,6 @@ return
 
 OpenSearchOnPoeTrade:
 	Global TradeOpts, Item
-	Item := {}
 	SuspendPOEItemScript = 1 ; This allows us to handle the clipboard change event
 	Send ^{sc02E}
 	Sleep 250
@@ -610,8 +605,7 @@ TradeFunc_Main(openSearchInBrowser = false, isAdvancedPriceCheck = false, isAdva
 		ShowToolTip(ParsedData)
 	}    
 	
-	; reset Item and ItemData after search
-	Item := {}
+	; reset ItemData after search
 	ItemData := {}
 	TradeGlobals.Set("AdvancedPriceCheckItem", {})
 }


### PR DESCRIPTION
* Renamed Item class to Item_

to avoid confusions

* quick fix for issues #209

Item := {} was creating new instance of blank object instead of just
resetting the value of the current instance.
In those 6 cases ParseItemData() will get called anyway and properly
reset the item instance values.