### PR TITLE
Show 4 decimal places for currency search

### DIFF
--- a/resources/ahk/TradeMacro.ahk
+++ b/resources/ahk/TradeMacro.ahk
@@ -1448,6 +1448,8 @@ TradeFunc_ParseCurrencyHtml(html, payload, ParsingError = "") {
 	Title .= StrPad("--------",8)		
 	Title .= "`n"
 	
+    SetFormat, float, 0.4
+
 	While A_Index < NoOfItemsToShow {
 		Offer       := TradeUtils.StrX( html,   "data-username=""",     N, 0, "Contact Seller"   , 1,1, N )
 		SellCurrency:= TradeUtils.StrX( Offer,  "data-sellcurrency=""", 1,19, """"        , 1,1, T )


### PR DESCRIPTION
Path of Exile and poe.trade both show up to 4 decimal places.

Since we pad to 20 characters, I see no reason to restrict display to 2 decimal places.

This also saves the user from interpreting integer ratios to deduce whether two offers are really the same or not:

1 <-- 0.02 | 197 <= 4
1 <-- 0.02 | 440 <= 9

It is not immediately obvious, whether these two offers are the same. With 4 decimal places:

1 <-- 0.0203 | 197 <= 4
1 <-- 0.0205 | 440 <= 9

It is immediately visible that the first offer is better.

On the other hand:

1 <-- 0.02 | 196 <= 4
1 <-- 0.02 | 441 <= 9

These offers really are the same, but it's not obvious from the integer ratios. If the user doesn't trust the 2 decimal spaces (he shouldn't), he will have to double check with a calculator. With 4 decimal places this will almost never be needed.

Such ratios are common for Chaos:Exalt trades.