### PR TITLE
Added mod_weight to _ParamMod in resources/ahk/TradeMacro.ahk

### DIFF
--- a/resources/ahk/TradeMacro.ahk
+++ b/resources/ahk/TradeMacro.ahk
@@ -2514,13 +2514,14 @@ class _ParamMod {
 	mod_name	:= ""
 	mod_min	:= ""
 	mod_max	:= ""
+	mod_weight := ""
 	ToPayload()
 	{
 		;this.mod_name	:= TradeUtils.UriEncode(this.mod_name)
 		;p := "&mod_name=" this.mod_name "&mod_min=" this.mod_min "&mod_max=" this.mod_max
 		If (StrLen(this.mod_name)) {
 			p .= "&mod_name=" TradeUtils.UriEncode(this.mod_name)
-			p .= "&mod_min="  TradeUtils.UriEncode(this.mod_min) "&mod_max="   TradeUtils.UriEncode(this.mod_max)
+			p .= "&mod_min="  TradeUtils.UriEncode(this.mod_min) "&mod_max="   TradeUtils.UriEncode(this.mod_max) "&mod_weight="   TradeUtils.UriEncode(this.mod_weight)
 		}
 
 		Return p


### PR DESCRIPTION
Added mod_weight to _ParamMod in a manner consistent with mod_min and mod_max to facilitate using existing portions of TM with "Weight" mod group types.