### PR TITLE
Fix GDI+.

### DIFF
--- a/lib/Gdip2.ahk
+++ b/lib/Gdip2.ahk
@@ -5,7 +5,7 @@ class Gdip
 		if !DllCall("GetModuleHandle", "str", "gdiplus")
 			DllCall("LoadLibrary", "str", "gdiplus")
 		VarSetCapacity(si, (A_PtrSize = 8) ? 24 : 16, 0), si := Chr(1)
-		DllCall("gdiplus\GdiplusStartup", "uptr*", pToken, "uptr", &si, "uint", 0)
+		DllCall("gdiplus\GdiplusStartup", "uptr*", pToken, "uptr", &si, "uptr", 0)
 		this.pToken := pToken
 	}
 	

--- a/lib/Gdip2.ahk
+++ b/lib/Gdip2.ahk
@@ -7,14 +7,6 @@ class Gdip
 		VarSetCapacity(si, (A_PtrSize = 8) ? 24 : 16, 0), si := Chr(1)
 		DllCall("gdiplus\GdiplusStartup", "uptr*", pToken, "uptr", &si, "uint", 0)
 		this.pToken := pToken
-
-		this._New := Gdip.__New
-		Gdip.__New := Gdip._DummyNew
-	}
-	
-	_DummyNew()
-	{
-		return false
 	}
 	
 	__Delete()


### PR DESCRIPTION
`InitGDITooltip` gets called multiple times.

This causes the `gdipTooltip` global to be created at least twice, the first time it's called, the `Gdip` class replaces the `__New` function with a stub.

`__New` is responsible for starting GDI+.

When the `gdipTooltip` global is replaced, it calls `Gdip.__Delete`, which calls `Gdip.Dispose`, which shuts down GDI+.

Once `gdipTooltip` is created a second time— it's now in a broken state, all GDI+ calls will now fail since GDI+ has been shut down.