### PR TITLE
Update Harbinger fragments/maps workaround.

### DIFF
--- a/resources/ahk/TradeMacro.ahk
+++ b/resources/ahk/TradeMacro.ahk
@@ -465,11 +465,6 @@ TradeFunc_Main(openSearchInBrowser = false, isAdvancedPriceCheck = false, isAdva
 		hasAdvancedSearch := true
 	}
 
-	; Harbinger fragments/maps are unique but not flagged as such on poe.trade
-	If (RegExMatch(Item.Name, "i)(First|Second|Third|Fourth) Piece of.*|The Beachhead.*")) {
-		Item.IsUnique 	:= false
-	}
-
 	/*
 		further item parsing and preparation
 		*/	
@@ -873,7 +868,10 @@ TradeFunc_Main(openSearchInBrowser = false, isAdvancedPriceCheck = false, isAdva
 			Item.UsedInSearch.Rarity := "Relic"
 		} Else If (Item.IsUnique) {
 			RequestParams.rarity := "unique"
-			RequestParams.xbase  := Item.BaseName
+			; Harbinger fragments/maps are unique but don't have a selectable base type on poe.trade
+			If (!RegExMatch(Item.Name, "i)(First|Second|Third|Fourth) Piece of.*|The Beachhead.*")) {
+				RequestParams.xbase  := Item.BaseName
+			}
 		}
 		Item.UsedInSearch.FullName := true
 	}

--- a/resources/ahk/TradeMacro.ahk
+++ b/resources/ahk/TradeMacro.ahk
@@ -868,8 +868,8 @@ TradeFunc_Main(openSearchInBrowser = false, isAdvancedPriceCheck = false, isAdva
 			Item.UsedInSearch.Rarity := "Relic"
 		} Else If (Item.IsUnique) {
 			RequestParams.rarity := "unique"
-			; Harbinger fragments/maps are unique but don't have a selectable base type on poe.trade
-			If (!RegExMatch(Item.Name, "i)(First|Second|Third|Fourth) Piece of.*|The Beachhead.*")) {
+			; Harbinger fragments are unique but don't have a selectable base type on poe.trade
+			If (!RegExMatch(Item.Name, "i)(First|Second|Third|Fourth) Piece of.*")) {
 				RequestParams.xbase  := Item.BaseName
 			}
 		}


### PR DESCRIPTION
poe.trade has fixed them not being unique, but their base types are not selectable so we still need a variant of the original workaround.

Fixes #961.