### PR TITLE
Properly decode download requests as UTF-8.

### DIFF
--- a/lib/PoEScripts_Download.ahk
+++ b/lib/PoEScripts_Download.ahk
@@ -132,7 +132,7 @@
 			commandHdr	.= "--connect-timeout " timeout " --max-time " timeout + 15 " "
 		}
 		; get data
-		html	:= StdOutStream(curl """" url """" commandData)
+		html	:= StdOutStream(curl """" url """" commandData,,"UTF-8")
 		
 		;html := ReadConsoleOutputFromFile(curl """" url """" commandData, "commandData") ; alternative function
 		
@@ -147,7 +147,7 @@
 			} Else {
 				commandHdr := curl """" url """" commandHdr
 			}
-			ioHdr := StdOutStream(commandHdr)
+			ioHdr := StdOutStream(commandHdr,,"UTF-8")
 			;ioHrd := ReadConsoleOutputFromFile(commandHdr, "commandHdr") ; alternative function
 		} Else If (skipRetHeaders) {
 			commandHdr := curl """" url """" commandHdr

--- a/resources/ahk/POE-ItemInfo.ahk
+++ b/resources/ahk/POE-ItemInfo.ahk
@@ -10416,7 +10416,7 @@ RemoveConfig(config = "config.ini")
 	FileDelete, %userDirectory%\%config%
 }
 
-StdOutStream(sCmd, Callback = "") {
+StdOutStream(sCmd, Callback = "", encoding = "CP850") {
 	/*
 		Runs commands in a hidden cmdlet window and returns the output.
 	*/
@@ -10469,7 +10469,7 @@ StdOutStream(sCmd, Callback = "") {
 
 	While DllCall( "ReadFile", UInt,hPipeRead, UInt,&Buffer, UInt,4094, UIntP,nSz, Int,0 ) {
 		tOutput := ( AIC && NumPut( 0, Buffer, nSz, "Char" ) && VarSetCapacity( Buffer,-1 ) )
-				? Buffer : %StrGet%( &Buffer, nSz, "CP850" )
+				? Buffer : %StrGet%( &Buffer, nSz, encoding )
 
 		Isfunc( Callback ) ? %Callback%( tOutput, A_Index ) : sOutput .= tOutput
 	}


### PR DESCRIPTION
This adjusts the return value of `PoEScripts_Download` so that it properly decodes UTF-8 data, allowing TradeMacro to properly handle Korean character names.

Currently search results have heavy use of `StrPad` for formatting, which this change butts right up against and will require further rework of tooltip rendering for these before this fix should be merged.

![unknown](https://user-images.githubusercontent.com/85170/59201179-70ac3a00-8b5f-11e9-9a69-60c8f74241eb.png)

As far as I can tell, all calls to `PoEScripts_Download` don't specify or otherwise ask for an encoding of `UTF-8`.

I left the default encoding as `CP850` to retain the previous behavior for unmodified calls to `StdOutStream`.