### PR TITLE
LookUpAffixes macro broken because of poeaffix

### DIFF
--- a/resources/ahk/POE-ItemInfo.ahk
+++ b/resources/ahk/POE-ItemInfo.ahk
@@ -11327,7 +11327,7 @@ LookUpAffixes() {
 				prefix	:= boots . chest . gloves . helmet . shield . gripType . ac . jw
 				StringLower, prefix, prefix
 
-				url		.= prefix "-" suffix ; ".html"
+				url		.= prefix "-" suffix ".html" ; ".html"
 			}
 			openWith := AssociatedProgram("html")
 			OpenWebPageWith(openWith, Url)


### PR DESCRIPTION
LookUpAffixes function is currently not working in Legion, maybe [poeaffix](http://poeaffix.net) has changed their URL structure because affix macro lookup is currently broken!  Adding ".html" to the end of the constructed poeaffix request URL and it works!